### PR TITLE
Fix broken pipeline due to CardTable2 "status" overhaul

### DIFF
--- a/.github/workflows/merge.yaml
+++ b/.github/workflows/merge.yaml
@@ -61,6 +61,7 @@ jobs:
             --assignments ../../src/assignments/assignments.yaml \
             --tcg ../../../tcg.vector.json \
             --ocg ../../../ocg.vector.json \
+            --unreleased ../../../yaml-yugipedia/semantic-mediawiki/unreleased.csv \
             --ko-official ../../../yaml-yugi-ko/_site/ocg.csv \
             --ko-override ../../../yaml-yugi-ko/ocg-override.csv \
             --ko-prerelease ../../../yaml-yugi-ko/ocg-prerelease.csv \

--- a/src/common.py
+++ b/src/common.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: © 2022–2023 Kevin Lu
+# SPDX-FileCopyrightText: © 2022–2024 Kevin Lu
 # SPDX-Licence-Identifier: AGPL-3.0-or-later
 from csv import DictReader
 import json
@@ -324,3 +324,11 @@ def replace_interlinear_annotations(name: str) -> str:
         .replace("\ufffa", "<rt>")
         .replace("\ufffb", "</rt></ruby>")
     )
+
+
+def load_unreleased_csv(filename: Optional[str]) -> Dict[str, Dict[str, str]]:
+    if not filename:
+        return {}
+    with open(filename) as f:
+        reader = DictReader(f)
+        return {row["English name"]: row for row in reader}

--- a/src/job_ocgtcg.py
+++ b/src/job_ocgtcg.py
@@ -63,6 +63,8 @@ def transform_structure(
         "limitation_text" in wikitext
         or
         # Boss Duel cards
+        wikitext.get("jp_sets", "").startswith("BD-JP")
+        or
         wikitext.get("ocg_status") == "Illegal"
         or
         # Details unavailable for a new leak

--- a/src/main_ocgtcg.py
+++ b/src/main_ocgtcg.py
@@ -17,6 +17,9 @@ parser.add_argument("--tcg", help="TCG Forbidden & Limited List, Konami ID vecto
 parser.add_argument(
     "--ocg", help="OCG Forbidden & Limited List, English name vector JSON"
 )
+parser.add_argument(
+    "--unreleased", help="Semantic MediaWiki unreleased cards CSV export"
+)
 parser.add_argument("--ko-official", help="yaml-yugi-ko official database CSV")
 parser.add_argument("--ko-override", help="yaml-yugi-ko ocg-override.csv")
 parser.add_argument("--ko-prerelease", help="yaml-yugi-ko ocg-prerelease.csv")
@@ -60,6 +63,7 @@ def main() -> None:
         args.assignments,
         tcg,
         ocg,
+        args.unreleased,
         args.ko_official,
         args.ko_override,
         args.ko_prerelease,


### PR DESCRIPTION
https://github.com/DawnbrandBots/yaml-yugipedia/commit/f39c06d99bc88bf3086576ec97b7735e6c101fcd
https://yugipedia.com/wiki/Template:CardTable2?action=history
https://yugipedia.com/index.php?title=Template%3ACardTable2&type=revision&diff=5412462&oldid=5380772

- [x] Continue to exclude Boss Duel cards
- [ ] Continue to exclude any other Illegal cards
- [ ] Compute release date ourselves
- [ ] Possibly other consequences TBD